### PR TITLE
Remove Web Protections

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -11,6 +11,9 @@ function createWindow() {
         darkTheme: true,
         fullscreen: process.env.NODE_ENV === "production",
         autoHideMenuBar: true,
+        webPreferences: {
+            webSecurity: false
+        }
     });
 
     let indexPath = "http://localhost:3000";
@@ -23,11 +26,11 @@ function createWindow() {
     mainWindow.on("closed", () => (mainWindow = null));
 }
 
-app.on("ready", () => {
-    createWindow();
-});
-// For sunrise and sunset times API. No SSL Certificate error.
+app.on("ready", () => createWindow());
+
+app.commandLine.appendSwitch("disable-site-isolation-trials");
 app.commandLine.appendSwitch("ignore-certificate-errors");
+
 app.on("window-all-closed", () => app.quit());
 app.on("activate", () => {
     if (mainWindow === null) createWindow();

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
             "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
-            "dev": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.1.0",
                 "@jridgewell/trace-mapping": "^0.3.9"
@@ -72,7 +71,6 @@
             "version": "7.20.5",
             "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.5.tgz",
             "integrity": "sha512-KZXo2t10+/jxmkhNXc7pZTqRvSOIvVv/+lJwHS+B2rErwOyjuVRh60yVpb7liQ1U5t7lLJ1bz+t8tSypUZdm0g==",
-            "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -81,7 +79,6 @@
             "version": "7.20.5",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.5.tgz",
             "integrity": "sha512-UdOWmk4pNWTm/4DlPUl/Pt4Gz4rcEMb7CY0Y3eJl5Yz1vI8ZJGmHWaVE55LoxRjdpx0z259GE9U5STA9atUinQ==",
-            "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.18.6",
@@ -111,7 +108,6 @@
             "version": "7.20.5",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.5.tgz",
             "integrity": "sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.20.5",
                 "@jridgewell/gen-mapping": "^0.3.2",
@@ -125,7 +121,6 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
             "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-            "dev": true,
             "dependencies": {
                 "@jridgewell/set-array": "^1.0.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -139,7 +134,6 @@
             "version": "7.20.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
             "integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
-            "dev": true,
             "dependencies": {
                 "@babel/compat-data": "^7.20.0",
                 "@babel/helper-validator-option": "^7.18.6",
@@ -157,7 +151,6 @@
             "version": "7.18.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
             "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
-            "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -166,7 +159,6 @@
             "version": "7.19.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
             "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
-            "dev": true,
             "dependencies": {
                 "@babel/template": "^7.18.10",
                 "@babel/types": "^7.19.0"
@@ -179,7 +171,6 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
             "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.18.6"
             },
@@ -202,7 +193,6 @@
             "version": "7.20.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
             "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
-            "dev": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-module-imports": "^7.18.6",
@@ -229,7 +219,6 @@
             "version": "7.20.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
             "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.20.2"
             },
@@ -241,7 +230,6 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
             "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.18.6"
             },
@@ -269,7 +257,6 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
             "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
-            "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -278,7 +265,6 @@
             "version": "7.20.6",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.6.tgz",
             "integrity": "sha512-Pf/OjgfgFRW5bApskEz5pvidpim7tEDPlFtKcNRXWmfHGn9IEI2W2flqRQXTFb7gIPTyK++N6rVHuwKut4XK6w==",
-            "dev": true,
             "dependencies": {
                 "@babel/template": "^7.18.10",
                 "@babel/traverse": "^7.20.5",
@@ -305,7 +291,6 @@
             "version": "7.20.5",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.5.tgz",
             "integrity": "sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==",
-            "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -372,7 +357,6 @@
             "version": "7.18.10",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
             "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
-            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.18.6",
                 "@babel/parser": "^7.18.10",
@@ -386,7 +370,6 @@
             "version": "7.20.5",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.5.tgz",
             "integrity": "sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==",
-            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.18.6",
                 "@babel/generator": "^7.20.5",
@@ -944,7 +927,6 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
             "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
-            "dev": true,
             "dependencies": {
                 "@jridgewell/set-array": "^1.0.0",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -957,7 +939,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
             "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-            "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -966,7 +947,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
             "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-            "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -974,14 +954,12 @@
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.4.14",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-            "dev": true
+            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.17",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
             "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
-            "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "3.1.0",
                 "@jridgewell/sourcemap-codec": "1.4.14"
@@ -1793,7 +1771,6 @@
             "version": "4.21.4",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
             "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
-            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -1958,7 +1935,6 @@
             "version": "1.0.30001439",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
             "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
-            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -2268,7 +2244,6 @@
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -2589,8 +2564,7 @@
         "node_modules/electron-to-chromium": {
             "version": "1.4.284",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-            "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
-            "dev": true
+            "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -2701,7 +2675,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
             "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -2884,7 +2857,6 @@
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
             "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-            "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -3011,7 +2983,6 @@
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -3396,7 +3367,6 @@
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
             "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-            "dev": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -3426,7 +3396,6 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
             "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-            "dev": true,
             "bin": {
                 "json5": "lib/cli.js"
             },
@@ -3830,8 +3799,7 @@
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/nan": {
             "version": "2.17.0",
@@ -4005,8 +3973,7 @@
         "node_modules/node-releases": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-            "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
-            "dev": true
+            "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
         },
         "node_modules/nopt": {
             "version": "6.0.0",
@@ -4298,8 +4265,7 @@
         "node_modules/picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-            "dev": true
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -4935,7 +4901,6 @@
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
             "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -5261,7 +5226,6 @@
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
             "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -5519,7 +5483,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
             "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
-            "dev": true,
             "requires": {
                 "@jridgewell/gen-mapping": "^0.1.0",
                 "@jridgewell/trace-mapping": "^0.3.9"
@@ -5536,14 +5499,12 @@
         "@babel/compat-data": {
             "version": "7.20.5",
             "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.5.tgz",
-            "integrity": "sha512-KZXo2t10+/jxmkhNXc7pZTqRvSOIvVv/+lJwHS+B2rErwOyjuVRh60yVpb7liQ1U5t7lLJ1bz+t8tSypUZdm0g==",
-            "dev": true
+            "integrity": "sha512-KZXo2t10+/jxmkhNXc7pZTqRvSOIvVv/+lJwHS+B2rErwOyjuVRh60yVpb7liQ1U5t7lLJ1bz+t8tSypUZdm0g=="
         },
         "@babel/core": {
             "version": "7.20.5",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.5.tgz",
             "integrity": "sha512-UdOWmk4pNWTm/4DlPUl/Pt4Gz4rcEMb7CY0Y3eJl5Yz1vI8ZJGmHWaVE55LoxRjdpx0z259GE9U5STA9atUinQ==",
-            "dev": true,
             "requires": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.18.6",
@@ -5566,7 +5527,6 @@
             "version": "7.20.5",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.5.tgz",
             "integrity": "sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.20.5",
                 "@jridgewell/gen-mapping": "^0.3.2",
@@ -5577,7 +5537,6 @@
                     "version": "0.3.2",
                     "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
                     "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-                    "dev": true,
                     "requires": {
                         "@jridgewell/set-array": "^1.0.1",
                         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -5590,7 +5549,6 @@
             "version": "7.20.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
             "integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
-            "dev": true,
             "requires": {
                 "@babel/compat-data": "^7.20.0",
                 "@babel/helper-validator-option": "^7.18.6",
@@ -5601,14 +5559,12 @@
         "@babel/helper-environment-visitor": {
             "version": "7.18.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-            "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
-            "dev": true
+            "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg=="
         },
         "@babel/helper-function-name": {
             "version": "7.19.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
             "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
-            "dev": true,
             "requires": {
                 "@babel/template": "^7.18.10",
                 "@babel/types": "^7.19.0"
@@ -5618,7 +5574,6 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
             "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.18.6"
             }
@@ -5635,7 +5590,6 @@
             "version": "7.20.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
             "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
-            "dev": true,
             "requires": {
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-module-imports": "^7.18.6",
@@ -5656,7 +5610,6 @@
             "version": "7.20.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
             "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.20.2"
             }
@@ -5665,7 +5618,6 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
             "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.18.6"
             }
@@ -5683,14 +5635,12 @@
         "@babel/helper-validator-option": {
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-            "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
-            "dev": true
+            "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw=="
         },
         "@babel/helpers": {
             "version": "7.20.6",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.6.tgz",
             "integrity": "sha512-Pf/OjgfgFRW5bApskEz5pvidpim7tEDPlFtKcNRXWmfHGn9IEI2W2flqRQXTFb7gIPTyK++N6rVHuwKut4XK6w==",
-            "dev": true,
             "requires": {
                 "@babel/template": "^7.18.10",
                 "@babel/traverse": "^7.20.5",
@@ -5710,8 +5660,7 @@
         "@babel/parser": {
             "version": "7.20.5",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.5.tgz",
-            "integrity": "sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==",
-            "dev": true
+            "integrity": "sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA=="
         },
         "@babel/plugin-syntax-jsx": {
             "version": "7.18.6",
@@ -5751,7 +5700,6 @@
             "version": "7.18.10",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
             "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.18.6",
                 "@babel/parser": "^7.18.10",
@@ -5762,7 +5710,6 @@
             "version": "7.20.5",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.5.tgz",
             "integrity": "sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.18.6",
                 "@babel/generator": "^7.20.5",
@@ -5904,7 +5851,8 @@
         "@emotion/use-insertion-effect-with-fallbacks": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
-            "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A=="
+            "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
+            "requires": {}
         },
         "@emotion/utils": {
             "version": "1.2.0",
@@ -6080,7 +6028,6 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
             "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
-            "dev": true,
             "requires": {
                 "@jridgewell/set-array": "^1.0.0",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -6089,26 +6036,22 @@
         "@jridgewell/resolve-uri": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-            "dev": true
+            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
         },
         "@jridgewell/set-array": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-            "dev": true
+            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
         },
         "@jridgewell/sourcemap-codec": {
             "version": "1.4.14",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-            "dev": true
+            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
         },
         "@jridgewell/trace-mapping": {
             "version": "0.3.17",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
             "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
-            "dev": true,
             "requires": {
                 "@jridgewell/resolve-uri": "3.1.0",
                 "@jridgewell/sourcemap-codec": "1.4.14"
@@ -6224,7 +6167,8 @@
         "@mui/types": {
             "version": "7.2.2",
             "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.2.tgz",
-            "integrity": "sha512-siex8cZDtWeC916cXOoUOnEQQejuMYmHtc4hM6VkKVYaBICz3VIiqyiAomRboTQHt2jchxQ5Q5ATlbcDekTxDA=="
+            "integrity": "sha512-siex8cZDtWeC916cXOoUOnEQQejuMYmHtc4hM6VkKVYaBICz3VIiqyiAomRboTQHt2jchxQ5Q5ATlbcDekTxDA==",
+            "requires": {}
         },
         "@mui/utils": {
             "version": "5.10.16",
@@ -6655,7 +6599,6 @@
             "version": "4.21.4",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
             "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
-            "dev": true,
             "requires": {
                 "caniuse-lite": "^1.0.30001400",
                 "electron-to-chromium": "^1.4.251",
@@ -6767,8 +6710,7 @@
         "caniuse-lite": {
             "version": "1.0.30001439",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
-            "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
-            "dev": true
+            "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A=="
         },
         "chalk": {
             "version": "2.4.2",
@@ -7014,7 +6956,6 @@
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
             "requires": {
                 "ms": "2.1.2"
             }
@@ -7243,8 +7184,7 @@
         "electron-to-chromium": {
             "version": "1.4.284",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-            "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
-            "dev": true
+            "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
         },
         "emoji-regex": {
             "version": "8.0.0",
@@ -7340,8 +7280,7 @@
         "escalade": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-            "dev": true
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
         },
         "escape-string-regexp": {
             "version": "4.0.0",
@@ -7470,8 +7409,7 @@
         "gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-            "dev": true
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
         },
         "get-caller-file": {
             "version": "2.0.5",
@@ -7563,8 +7501,7 @@
         "globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-            "dev": true
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
         },
         "globalthis": {
             "version": "1.0.3",
@@ -7855,8 +7792,7 @@
         "jsesc": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-            "dev": true
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
         },
         "json-buffer": {
             "version": "3.0.1",
@@ -7879,8 +7815,7 @@
         "json5": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-            "dev": true
+            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
         },
         "jsonfile": {
             "version": "4.0.0",
@@ -8181,8 +8116,7 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "nan": {
             "version": "2.17.0",
@@ -8312,8 +8246,7 @@
         "node-releases": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-            "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
-            "dev": true
+            "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
         },
         "nopt": {
             "version": "6.0.0",
@@ -8520,8 +8453,7 @@
         "picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-            "dev": true
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
         },
         "picomatch": {
             "version": "2.3.1",
@@ -9002,8 +8934,7 @@
         "semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "semver-compare": {
             "version": "1.0.0",
@@ -9244,7 +9175,6 @@
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
             "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
-            "dev": true,
             "requires": {
                 "escalade": "^3.1.1",
                 "picocolors": "^1.0.0"

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -51,7 +51,7 @@ const App = () => {
         const sunriseHour = DateTime.fromISO(sunData.results.sunrise).hour;
 
         if (nowHour < sunriseHour + 1 || nowHour > sunsetHour + 1) {
-            mode = "light";
+            mode = "dark";
         }
     }
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -51,7 +51,7 @@ const App = () => {
         const sunriseHour = DateTime.fromISO(sunData.results.sunrise).hour;
 
         if (nowHour < sunriseHour + 1 || nowHour > sunsetHour + 1) {
-            mode = "dark";
+            mode = "light";
         }
     }
 

--- a/src/components/Cards/MountainMapCard.tsx
+++ b/src/components/Cards/MountainMapCard.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import {
     Box,
@@ -50,15 +50,52 @@ const MountainMapCard = () => {
 };
 
 const SteamboatInteractiveMap = () => {
+    const mapRef = useRef<HTMLIFrameElement>(null);
+
+    useEffect(() => {
+        const iframeReactLoadDelayTimeout = setTimeout(() => {
+            if (mapRef.current) {
+                const iframeWindow = mapRef.current.contentWindow;
+                setUserAgent(iframeWindow, "Mozilla/5.0");
+
+                const iframeDocument = iframeWindow?.document;
+                if (iframeDocument) {
+                    [
+                        iframeDocument.getElementById("fullscreen"),
+                        iframeDocument.getElementById("zoomControls"),
+                        iframeDocument.getElementById("menu")
+                    ].forEach((element) => element?.remove());
+                }
+            }
+        }, 1000);
+        return () => clearTimeout(iframeReactLoadDelayTimeout);
+    }, [mapRef]);
+
+    const setUserAgent = (window: any, userAgent: any) => {
+        if (window.navigator.userAgent != userAgent) {
+            var userAgentProp = {
+                get: function () {
+                    return userAgent;
+                }
+            };
+            try {
+                Object.defineProperty(window.navigator, "userAgent", userAgentProp);
+            } catch (e) {
+                window.navigator = Object.create(navigator, {
+                    userAgent: userAgentProp
+                });
+            }
+        }
+    };
+
     return (
         <iframe
-            id="Steamboat Map"
-            src="https://vicomap-cdn.resorts-interactive.com/map/1800?fullscreen=true&menu=3.7,3.10,3.14&openLiftAnimation=true&openLiftColor=green&liftHighlightOpacity=0.1&backgroundOpacity=0.5"
+            src="https://vicomap-cdn.resorts-interactive.com/map/1800?fullscreen=true&menu=3.7,3.10,3.14&openLiftAnimation=false&openLiftColor=green&liftHighlightOpacity=0.1&backgroundOpacity=0.5"
             width="100%"
             height="100%"
             allowFullScreen
-            title="Vicomap"
-            style={{ pointerEvents: "auto" }}
+            style={{ border: "none", pointerEvents: "auto" }}
+            ref={mapRef}
         />
     );
 };

--- a/src/components/Cards/MountainMapCard.tsx
+++ b/src/components/Cards/MountainMapCard.tsx
@@ -71,19 +71,13 @@ const SteamboatInteractiveMap = () => {
         return () => clearTimeout(iframeReactLoadDelayTimeout);
     }, [mapRef]);
 
-    const setUserAgent = (window: any, userAgent: any) => {
-        if (window.navigator.userAgent != userAgent) {
-            var userAgentProp = {
-                get: function () {
-                    return userAgent;
-                }
-            };
+    const setUserAgent = (window: Window | null, userAgent: string) => {
+        if (window && window.navigator.userAgent != userAgent) {
+            const userAgentProp = { get: () => userAgent };
             try {
                 Object.defineProperty(window.navigator, "userAgent", userAgentProp);
             } catch (e) {
-                window.navigator = Object.create(navigator, {
-                    userAgent: userAgentProp
-                });
+                (window as any).navigator = Object.create(navigator, { userAgent: userAgentProp });
             }
         }
     };


### PR DESCRIPTION
This is probably a bad idea, but it gets the job done and honestly there is no other way. Basically, by default all Browsers have protections to prevent users from getting scammed. In essence, Ive disabled the MOST important one of all, cross-origin scripting.

What this means is that we are allowed to edit the contents of an iframe. In general this is a bad idea for a browser, as for example a website could open an iframe of your banks website, access your cookies to login, and then immediately use JS to withdraw a ton of money to an offshore account.

In practice though, the electron environment is isolated, there is zero possibility for injection attacks, and most importantly, we are the website in question. Therefore, I can use our control of the browser to disable protections.

I edit the map user agent, which may enable touch interaction. I also turn off the animations until we can diagnose the rendering overhead there.

To readd the zoom buttons, we should add them using MUI, but I would rather it just be zoom via touch controls.

fixes #18